### PR TITLE
Typo

### DIFF
--- a/docs/guide/08-docs/03-configuration.md
+++ b/docs/guide/08-docs/03-configuration.md
@@ -126,7 +126,7 @@ fractal.docs.set('statuses', {
 How the collection of documentation pages will be referenced in any titles.
 
 ```js
-fractal.components.set('title', 'Pages'); // default is 'Documentation'
+fractal.docs.set('title', 'Pages'); // default is 'Documentation'
 ```
 
 ## Page properties


### PR DESCRIPTION
I think `fractal.components.set` should be `fractal.docs.set` here, right?